### PR TITLE
Fix Vercel deployment: resolve date-fns dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
     "express": "4",
     "framer-motion": "^12.23.12",


### PR DESCRIPTION
This PR fixes the Vercel deployment failure caused by a dependency conflict between date-fns@4.1.0 and react-day-picker@8.10.1.

## Changes
- Downgraded date-fns from ^4.1.0 to ^3.6.0 to satisfy react-day-picker's peer dependency requirements (^2.28.0 || ^3.0.0)

## Impact
- Resolves Vercel build failures
- Maintains compatibility with all other dependencies
- Allows successful deployment of Nelson Medical Assistant

This fix ensures the deployment will succeed without any breaking changes to the application functionality.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view jam](https://scout.new/jam/8a607182-daed-4bca-9220-ddb06c2797d2))